### PR TITLE
feat(dict): allow support of multi dictionaries and min length

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,15 @@ Results will contain an Array of Objects with the following format:
 ## Default options
 ````javascript
 {
+    dicts: [{ // Path of dictionaries to use. Can be a string or an object like { aff: <<String>>, dic: <<String>> }
+        aff: 'dicts/en_US.aff',
+        dic: 'dicts/en_US.dic'
+    }],
     checkers: ['identifier', 'string', 'comment'], // locations where to check words
     color: true, // If true, return colored and bold messages
     hideSuccessful: true, // If true, return only the misspelled results
-    skipWords: [] // Additional words to ignore and do not mark as misspelled 
+    skipWords: [], // Additional words to ignore and do not mark as misspelled
+    minLength: 0 // Words with a length less than minLength won't be checked
 }
 ````
 ## Test

--- a/hunspellchecker.js
+++ b/hunspellchecker.js
@@ -3,11 +3,44 @@ We use 'US'' as  default dictionaries
 */
 
 var Spellchecker = require('hunspell-spellchecker');
+var Dictionary = require('hunspell-spellchecker/lib/dictionary');
 var fs = require('fs');
-var spellchecker = new Spellchecker();
-var DICT = spellchecker.parse({
-    aff: fs.readFileSync(__dirname + '/dicts/en_US.aff'),
-    dic: fs.readFileSync(__dirname + '/dicts/en_US.dic')
-});
-spellchecker.use(DICT);
-module.exports = spellchecker;
+var _ = require('lodash');
+
+var MultiDictionary = function(dicts) {
+    Dictionary.call(this, dicts);
+};
+
+MultiDictionary.prototype = Object.create(Dictionary.prototype);
+
+MultiDictionary.prototype.load = function(dicts) {
+    var self = this;
+    _.forEach(dicts, function (dic) {
+        self.rules = _.extend(self.rules, dic.rules);
+        self.dictionaryTable = _.extend(self.dictionaryTable, dic.dictionaryTable);
+        self.compoundRules = _.union(self.compoundRules, dic.compoundRules);
+        self.compoundRuleCodes = _.extend(self.compoundRuleCodes, dic.compoundRuleCodes);
+        self.replacementTable = _.union(self.replacementTable, dic.replacementTable);
+        self.flags = _.extend(self.flags, dic.flags);
+    });
+};
+
+module.exports = function (dictsConfig) {
+    var spellchecker = new Spellchecker();
+    var dicts = [];
+    _.forEach(dictsConfig, function(dictConfig) {
+        var aff = _.isString(dictConfig) && _.endsWith(dictConfig, 'aff') ? aff : dictConfig.aff;
+        var dic = _.isString(dictConfig) && _.endsWith(dictConfig, 'dic') ? dictConfig : dictConfig.dic;
+        var dict = {};
+        if (!_.isEmpty(aff)) {
+            dict.aff = fs.readFileSync(aff);
+        }
+        if (!_.isEmpty(dic)) {
+            dict.dic = fs.readFileSync(dic);
+        }
+        dicts.push(spellchecker.parse(dict));
+    });
+    var DICT = new MultiDictionary(dicts);
+    spellchecker.use(DICT);
+    return spellchecker;
+}


### PR DESCRIPTION
Allow to add dictionaries to the spell checker:

``` javascript
new JsSpellChecker({
  dicts: [
    {
      aff: __dirname + '/../node_modules/lintspelljs/dicts/en_US.aff',
      dic: __dirname + '/../node_modules/lintspelljs/dicts/en_US.dic'
    },
    __dirname + '/../dicts/english.dic',
    __dirname + '/../dicts/jetbrains.dic'
  ]
});
```

And allow to pass words less than a minimum length:

``` javascript
new JsSpellChecker({
  minLength: 4
});
```

With this parameter, words with a length less than _minLength_ will not be checked. It's useful for single-letter words.
